### PR TITLE
Use env var for service public port

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -41,7 +41,8 @@ func Register() *server.Hertz {
 
 	// Set localIP for serviceHost
 	serviceHost := cfg.GetString("APP_URL", "http://localhost")
-	addr := net.JoinHostPort(serviceHost, cfg.GetString("APP_PORT", "8000"))
+	servicePort := cfg.GetString("APP_PUBLIC_PORT", "80")
+	addr := net.JoinHostPort(serviceHost, servicePort)
 	r = consul.NewConsulRegister(consulClient)
 	info = &registry.Info{
 		ServiceName: cfg.GetString("APP_MODULE", "Demo"),


### PR DESCRIPTION
Have a clear difference between the exposed port Consul sees and internal port Hertz runs on