### PR TITLE
Do not redirect trailing slash

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -54,6 +54,7 @@ func Register() *server.Hertz {
 	s := "0.0.0.0:" + cfg.GetString("APP_PORT")
 	h = server.Default(
 		server.WithHostPorts(s),
+		server.WithRedirectTrailingSlash(false),
 		server.WithRegistry(r, info),
 	)
 	return h

--- a/server.go
+++ b/server.go
@@ -25,6 +25,7 @@ func Boot() *server.Hertz {
 		fmt.Println("Skipping Consul service registration")
 		h = server.Default(
 			server.WithHostPorts(s),
+			server.WithRedirectTrailingSlash(false),
 			server.WithOnConnect(svrconn),
 		)
 	}


### PR DESCRIPTION
Testing for nginx auth_request module, to not redirect trailing slashes as it is how it defines absolute uris